### PR TITLE
Fixing regex due to Traefik update

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,8 +60,8 @@ matrix_swiclops_container_arguments: []
 matrix_swiclops_container_labels_traefik_enabled: true
 matrix_swiclops_container_labels_traefik_docker_network: "{{ matrix_swiclops_container_network }}"
 
-matrix_swiclops_container_labels_traefik_uia_path_prefix: "{{ matrix_swiclops_uia_endpoint_prefix + matrix_swiclops_uia_endpoint_version + '{endpoint:(' + matrix_swiclops_uia_endpoints | join('|') + ')}' }}"
-matrix_swiclops_container_labels_traefik_uia_rule: "Host(`{{ matrix_server_fqn_matrix }}`) && PathPrefix(`{{ matrix_swiclops_container_labels_traefik_uia_path_prefix }}`)"
+matrix_swiclops_container_labels_traefik_uia_path_regexp: "{{ matrix_swiclops_uia_endpoint_prefix + matrix_swiclops_uia_endpoint_version + '(?P<endpoint>(' + matrix_swiclops_uia_endpoints | join('|') + '))' }}"
+matrix_swiclops_container_labels_traefik_uia_rule: "Host(`{{ matrix_server_fqn_matrix }}`) && PathRegexp(`{{ matrix_swiclops_container_labels_traefik_uia_path_regexp }}`)"
 matrix_swiclops_container_labels_traefik_uia_priority: 0
 matrix_swiclops_container_labels_traefik_uia_entrypoints: web-secure
 matrix_swiclops_container_labels_traefik_uia_tls: "{{ matrix_swiclops_container_labels_traefik_uia_entrypoints != 'web' }}"
@@ -76,8 +76,8 @@ matrix_swiclops_container_labels_traefik_swiclops_tls_certResolver: default  # n
 
 # This is like `matrix_swiclops_container_labels_traefik_uia_*`, but on an internal Traefik entrypoint.
 matrix_swiclops_container_labels_traefik_internal_uia_enabled: false
-matrix_swiclops_container_labels_traefik_internal_uia_path_prefix: "{{ matrix_swiclops_container_labels_traefik_uia_path_prefix }}"
-matrix_swiclops_container_labels_traefik_internal_uia_rule: "PathPrefix(`{{ matrix_swiclops_container_labels_traefik_internal_uia_path_prefix }}`)"
+matrix_swiclops_container_labels_traefik_internal_uia_path_regexp: "{{ matrix_swiclops_container_labels_traefik_uia_path_regexp }}"
+matrix_swiclops_container_labels_traefik_internal_uia_rule: "PathRegexp(`{{ matrix_swiclops_container_labels_traefik_internal_uia_path_regexp }}`)"
 matrix_swiclops_container_labels_traefik_internal_uia_priority: "{{ matrix_swiclops_container_labels_traefik_uia_priority }}"
 matrix_swiclops_container_labels_traefik_internal_uia_entrypoints: ""
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,7 +4,7 @@
 matrix_swiclops_role_executed: false
 
 matrix_swiclops_uia_endpoint_prefix: "/_matrix/client/"
-matrix_swiclops_uia_endpoint_version: "{version:(api/v1|r0|v3|unstable)}/"
+matrix_swiclops_uia_endpoint_version: "(?P<version>(api/v1|r0|v3|unstable))/"
 
 matrix_swiclops_uia_endpoints:
   - register


### PR DESCRIPTION
The base playbook updated Traefik to v3 (https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/CHANGELOG.md#traefik-v3-and-http3-are-here-now), and broke regex expressions. This PR address that issue.